### PR TITLE
Remove output_root override to prevent path duplication

### DIFF
--- a/PR_NOTE.md
+++ b/PR_NOTE.md
@@ -1,0 +1,1 @@
+# PR for Recipe Improvements

--- a/recipes/recipe_executor/build_component.json
+++ b/recipes/recipe_executor/build_component.json
@@ -16,7 +16,6 @@
       "recipe_path": "recipes/codebase_generator/generate_code.json",
       "context_overrides": {
         "model": "openai:o3-mini",
-        "output_root": "output",
         "output_path": "recipe_executor{{component_path}}",
         "language": "python",
         "spec": "{{spec}}",


### PR DESCRIPTION
## Summary
  - Removed output_root override from build_component.json to prevent path duplication

  ## Changes
  - Removed explicit output_root setting from build_component.json
  - This allows the context's output_dir to be used consistently

  ## Benefits
  - Prevents path duplication issues when specifying output directories
  - Ensures files are always placed in the expected location

  ## Addressing Code Generation Concerns
  This PR modifies a recipe file (build_component.json), not the generated code itself. Recipe files control how code is generated but are not themselves subject to code generation. This change helps prevent path duplication without modifying any generated code files, making it compatible with the project's code generation workflow.