### PR TITLE
Avoids circular reference to Executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ recipe-executor-context:
 .PHONY: recipe-executor-create
 recipe-executor-create:
 	@echo "Generating recipe executor code from scratch from recipe..."
-	@python recipe_executor/main.py recipes/recipe_executor/create.json
+	@recipe-executor recipes/recipe_executor/create.json
 
 # Edit/revise the existing recipe executor code using the recipe executor itself
 .PHONY: recipe-executor-edit
 recipe-executor-edit:
 	@echo "Revising the existing recipe executor code from recipe..."
-	@python recipe_executor/main.py recipes/recipe_executor/edit.json
+	@recipe-executor recipes/recipe_executor/edit.json

--- a/recipe_executor/main.py
+++ b/recipe_executor/main.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 from dotenv import load_dotenv
 
 from recipe_executor.context import Context
-from executor import Executor
+from recipe_executor.executor import Executor
 from recipe_executor.logger import init_logger
 
 
@@ -29,9 +29,9 @@ def parse_context(context_list: Optional[list]) -> Dict[str, str]:
         return context_dict
 
     for item in context_list:
-        if '=' not in item:
+        if "=" not in item:
             raise ValueError(f"Invalid context format: '{item}'. Expected key=value.")
-        key, value = item.split('=', 1)
+        key, value = item.split("=", 1)
         if not key:
             raise ValueError(f"Context key cannot be empty in pair: '{item}'.")
         context_dict[key] = value
@@ -44,21 +44,10 @@ def main() -> None:
 
     # Setup argument parser
     parser = argparse.ArgumentParser(description="Recipe Executor Tool")
+    parser.add_argument("recipe_path", type=str, help="Path to the recipe file to execute")
+    parser.add_argument("--log-dir", type=str, default="logs", help="Directory for log files (default: logs)")
     parser.add_argument(
-        "recipe_path",
-        type=str,
-        help="Path to the recipe file to execute"
-    )
-    parser.add_argument(
-        "--log-dir",
-        type=str,
-        default="logs",
-        help="Directory for log files (default: logs)"
-    )
-    parser.add_argument(
-        "--context",
-        action="append",
-        help="Context values as key=value pairs (can be used multiple times)"
+        "--context", action="append", help="Context values as key=value pairs (can be used multiple times)"
     )
 
     args = parser.parse_args()
@@ -82,11 +71,11 @@ def main() -> None:
     logger.debug(f"Starting main function with arguments: {args}")
     logger.debug(f"Context artifacts: {context_artifacts}")
 
-    # Create the execution context
-    context = Context(artifacts=context_artifacts)
-
     # Initialize Executor
     executor = Executor()
+
+    # Create the execution context
+    context = Context(executor=executor, artifacts=context_artifacts)
 
     try:
         logger.info("Starting Recipe Executor Tool")
@@ -109,5 +98,5 @@ def main() -> None:
         logger.info(f"Total execution time: {elapsed_time:.2f} seconds")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/recipe_executor/steps/execute_recipe.py
+++ b/recipe_executor/steps/execute_recipe.py
@@ -1,9 +1,8 @@
 import os
-from typing import Dict, Any
+from typing import Any, Dict
 
-from recipe_executor.steps.base import BaseStep, StepConfig
-from recipe_executor.executor import Executor
 from recipe_executor.context import Context
+from recipe_executor.steps.base import BaseStep, StepConfig
 from recipe_executor.utils import render_template
 
 
@@ -14,6 +13,7 @@ class ExecuteRecipeConfig(StepConfig):
         recipe_path: Path to the recipe to execute.
         context_overrides: Optional values to override in the context.
     """
+
     recipe_path: str
     context_overrides: Dict[str, str] = {}
 
@@ -21,8 +21,8 @@ class ExecuteRecipeConfig(StepConfig):
 class ExecuteRecipeStep(BaseStep[ExecuteRecipeConfig]):
     """Step that executes a sub-recipe with optional context overrides.
 
-    This component uses template rendering for dynamic resolution of recipe paths and context overrides, 
-    validates that the target recipe file exists, applies context overrides, and executes the sub-recipe 
+    This component uses template rendering for dynamic resolution of recipe paths and context overrides,
+    validates that the target recipe file exists, applies context overrides, and executes the sub-recipe
     using a shared Executor instance. Execution start and completion are logged as info messages.
     """
 
@@ -41,29 +41,28 @@ class ExecuteRecipeStep(BaseStep[ExecuteRecipeConfig]):
         try:
             # Render the recipe path using the current context
             rendered_recipe_path = render_template(self.config.recipe_path, context)
-            
+
             # Render context overrides
             rendered_overrides: Dict[str, str] = {}
             for key, value in self.config.context_overrides.items():
                 rendered_overrides[key] = render_template(value, context)
-            
+
             # Validate that the sub-recipe file exists
             if not os.path.isfile(rendered_recipe_path):
                 error_msg = f"Sub-recipe file not found: {rendered_recipe_path}"
                 self.logger.error(error_msg)
                 raise RuntimeError(error_msg)
-            
+
             # Log start of execution
             self.logger.info(f"Starting execution of sub-recipe: {rendered_recipe_path}")
-            
+
             # Apply context overrides before sub-recipe execution
             for key, value in rendered_overrides.items():
                 context[key] = value
-            
+
             # Execute the sub-recipe with the same context and logger
-            executor = Executor()
-            executor.execute(rendered_recipe_path, context, self.logger)
-            
+            context.executor.execute(rendered_recipe_path, context, self.logger)
+
             # Log completion of sub-recipe execution
             self.logger.info(f"Completed execution of sub-recipe: {rendered_recipe_path}")
 


### PR DESCRIPTION
- Previously: Executor -> Step -> (global) Executor
- Now: Executor -> Step -> Context.Executor

This allows the `recipe-executor` script to work, so it can be called directly instead of running the main.py file as a script. The Makefile is updated to use the recipe-executor script.

Additionally there was some lint that ruff formatting corrected.